### PR TITLE
Fix sticky Bar issue

### DIFF
--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -2580,8 +2580,10 @@ td.indented {
 .form-simple select, .form-simple input, .form-simple textarea {
     margin-left: 0;
 }
-.sticky.bar.fixed {
-  position: fixed;
+
+/* Commenting this removes issues with flickering bar*/
+/* .sticky.bar.fixed {
+  position: fixed; 
   top: 0;
   left: 0;
   z-index: 6;
@@ -2591,7 +2593,7 @@ td.indented {
   padding: 10px 20px;
   box-sizing: border-box;
   box-shadow: 0 3px 10px rgba(0,0,0,0.3);
-}
+} */
 .sticky.bar .content {
   margin: auto;
 }


### PR DESCRIPTION
Before this the open tickets control bar would flicker on larger screens where there was very little scroll below the list of tickets. This fixes this issue without affecting usability