### PR TITLE
Update theme.css - remove inline block

### DIFF
--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -116,7 +116,6 @@ fieldset {
 a, .link {
   color: #00AEEF;
   text-decoration: none;
-  display: inline-block;
   margin-bottom: 1px;
 }
 a:hover, .link:hover {


### PR DESCRIPTION
Removed display: inline-block; from "a, .link" at line 119 to fix FAQ spacing issue.